### PR TITLE
Add documentation label

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -36,12 +36,13 @@ When merging into `master`, we use the "squash and merge" method. This takes all
 ### Labels
 Below is a list of labels that we use in the repo and how we use them.
 
-| Label         | Description                                                                           |
-|---------------|---------------------------------------------------------------------------------------|
-| `bug`         | A bug concerning functionality in the app. (e.g. Users cannot sign into a service)    |
-| `ui-bug`      | A bug concerning UI elements. (e.g. The Search bar does not display properly)         |
-| `enhancement` | A new feature or change in the way a portion of the app functions or looks.           |
-| `help-wanted` | Issues that the Kleene team is looking for outside help on.                           |
-| `invalid`     | A non-issue or something that is working as intended.                                 |
-| `duplicate`   | A duplicate of another issue or pull request. Most likely will be closed.             |
-| `wontfix`     | Something the team has deemed unimportant for the time being. May be addressed later. |
+| Label           | Description                                                                           |
+|-----------------|---------------------------------------------------------------------------------------|
+| `bug`           | A bug concerning functionality in the app. (e.g. Users cannot sign into a service)    |
+| `ui bug`        | A bug concerning UI elements. (e.g. The Search bar does not display properly)         |
+| `enhancement`   | A new feature or change in the way a portion of the app functions or looks.           |
+| `help wanted`   | Issues that the Kleene team is looking for outside help on.                           |
+| `documentation` | Improvements or additions to documentation.                                           |
+| `invalid`       | A non-issue or something that is working as intended.                                 |
+| `duplicate`     | A duplicate of another issue or pull request. Most likely will be closed.             |
+| `wontfix`       | Something the team has deemed unimportant for the time being. May be addressed later. |


### PR DESCRIPTION
Add `documentation` label, remove hyphens from label names

### Prerequisites

- [X] Put an X between the brackets on this line if you have done all of the following:
	- Checked the [pull requests list](https://github.com/KleeneApp/Kleene/pulls) to see if this has already been opened.
	- Checked the current code base to match styling and standards.
	- Read the [contributing guidelines](CONTRIBUTING.md).

### Description of Changes

This adds the `documentation` label to the contributing guidelines.

### Verification Process

The markdown renders properly.

### Release Notes

N/A -- documentation
